### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,25 @@ dependencies {
             }
         }
 
-        
+        implementation('com.fasterxml.jackson.core:jackson-core') {
+            because 'version imported as a dependency has a vulnerability'
+            version {
+                strictly '2.18.6'
+            }
+        }
+
+        implementation('com.fasterxml.jackson.core:jackson-annotations') {
+            because 'version imported as a dependency has a vulnerability'
+            version {
+                strictly '2.18.6'
+            }
+        }
+
+        implementation('com.fasterxml.jackson.core:jackson-databind') {
+            because 'version imported as a dependency has a vulnerability'
+            version {
+                strictly '2.18.6'
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed OSV scanner build failure by bumping com.fasterxml.jackson.core libraries to 2.18.6 to resolve vulnerability GHSA-72hv-8253-57qq in jackson-core. Updated constraints in build.gradle and ran `./gradlew dependencies --write-locks` to update `gradle.lockfile`.

---
*PR created automatically by Jules for task [14593616724433895198](https://jules.google.com/task/14593616724433895198) started by @boxheed*