### PR TITLE
Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,19 @@ dependencies {
             }
         }
 
+        implementation('com.fasterxml.jackson.core:jackson-databind') {
+            because 'version 2.20.0 imported as a dependency has a vulnerability'
+            version {
+                require '2.21.1'
+            }
+        }
+        implementation('com.fasterxml.jackson.core:jackson-core') {
+            because 'version 2.20.0 imported as a dependency has a vulnerability'
+            version {
+                require '2.21.1'
+            }
+        }
+
         
     }
 }


### PR DESCRIPTION
Fixed a vulnerability scanning failure (GHSA-72hv-8253-57qq) caused by `com.fasterxml.jackson.core:jackson-core:2.20.0` by forcing an upgrade to `2.21.1` in the dependency constraints block in `build.gradle`. We also had to bump `jackson-databind` to `2.21.1` to align with the core upgrade and keep the resolution sound.

---
*PR created automatically by Jules for task [16957833518519475102](https://jules.google.com/task/16957833518519475102) started by @boxheed*