### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,12 @@ dependencies {
             }
         }
 
+        implementation('com.fasterxml.jackson.core:jackson-core') {
+            because 'version 2.20.0 imported as a dependency has a vulnerability'
+            version {
+                require '2.21.1'
+            }
+        }
         
     }
 }


### PR DESCRIPTION
Fixes the OSV scanner build failure by restricting `com.fasterxml.jackson.core:jackson-core` to a non-vulnerable version via the dependencies constraint block in `build.gradle`.

---
*PR created automatically by Jules for task [2115917924593316702](https://jules.google.com/task/2115917924593316702) started by @boxheed*