### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,13 +8,13 @@ buildscript {
     }
     dependencies {
         classpath 'com.gradle.publish:plugin-publish-plugin:2.1.1'
-        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
+        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
         classpath 'com.fizzpod:gradle-git-semver-plugin:0.4.4'
         classpath 'com.fizzpod:gradle-github-release-plugin:3.2.1'
         classpath 'com.fizzpod:gradle-gitignore-plugin:5.0.4'
         classpath 'com.fizzpod:gradle-layout-plugin:6.1.1'
         classpath 'com.fizzpod:gradle-lefthook-plugin:0.4.2'
-        classpath 'com.fizzpod:gradle-osv-scanner-plugin:5.0.7'
+        classpath 'com.fizzpod:gradle-osv-scanner-plugin:5.0.8'
         classpath 'com.fizzpod:gradle-sweeney-plugin:7.0.6'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.54.0'
         classpath 'com.gradle:develocity-gradle-plugin:4.4.0'
@@ -41,13 +41,13 @@ compileGroovy {
 
 dependencies {
     runtimeOnly 'com.gradle.publish:plugin-publish-plugin:2.1.1'
-    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
+    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
     runtimeOnly 'com.fizzpod:gradle-git-semver-plugin:0.4.4'
     runtimeOnly 'com.fizzpod:gradle-github-release-plugin:3.2.1'
     runtimeOnly 'com.fizzpod:gradle-gitignore-plugin:5.0.4'
     runtimeOnly 'com.fizzpod:gradle-layout-plugin:6.1.1'
     runtimeOnly 'com.fizzpod:gradle-lefthook-plugin:0.4.2'
-    runtimeOnly 'com.fizzpod:gradle-osv-scanner-plugin:5.0.7'
+    runtimeOnly 'com.fizzpod:gradle-osv-scanner-plugin:5.0.8'
     runtimeOnly 'com.fizzpod:gradle-pater-build-plugin:4.0.5'
     runtimeOnly 'com.fizzpod:gradle-sweeney-plugin:7.0.6'
     runtimeOnly 'com.github.ben-manes:gradle-versions-plugin:0.54.0'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.gradle.publish:plugin-publish-plugin:2.1.1'
-        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
+        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
         classpath 'com.fizzpod:gradle-git-semver-plugin:0.4.4'
         classpath 'com.fizzpod:gradle-github-release-plugin:3.2.1'
         classpath 'com.fizzpod:gradle-gitignore-plugin:5.0.4'
@@ -41,7 +41,7 @@ compileGroovy {
 
 dependencies {
     runtimeOnly 'com.gradle.publish:plugin-publish-plugin:2.1.1'
-    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
+    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
     runtimeOnly 'com.fizzpod:gradle-git-semver-plugin:0.4.4'
     runtimeOnly 'com.fizzpod:gradle-github-release-plugin:3.2.1'
     runtimeOnly 'com.fizzpod:gradle-gitignore-plugin:5.0.4'


### PR DESCRIPTION
Automated fix for dependency update failure in `gradle-extended-info-plugin` which was unexpectedly updated from 15.0.7 to 15.0.8 by Dependabot, though 15.0.8 doesn't exist yet. Reverted `gradle-extended-info-plugin` back to 15.0.7.

---
*PR created automatically by Jules for task [14213878298706836077](https://jules.google.com/task/14213878298706836077) started by @boxheed*