### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.gradle.publish:plugin-publish-plugin:2.1.1'
-        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
+        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
         classpath 'com.fizzpod:gradle-git-semver-plugin:0.4.4'
         classpath 'com.fizzpod:gradle-github-release-plugin:3.2.1'
         classpath 'com.fizzpod:gradle-gitignore-plugin:5.0.4'
@@ -41,7 +41,7 @@ compileGroovy {
 
 dependencies {
     runtimeOnly 'com.gradle.publish:plugin-publish-plugin:2.1.1'
-    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
+    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
     runtimeOnly 'com.fizzpod:gradle-git-semver-plugin:0.4.4'
     runtimeOnly 'com.fizzpod:gradle-github-release-plugin:3.2.1'
     runtimeOnly 'com.fizzpod:gradle-gitignore-plugin:5.0.4'


### PR DESCRIPTION
Reverted incorrect version bump of `gradle-extended-info-plugin` to 15.0.8. Version 15.0.8 does not exist.

---
*PR created automatically by Jules for task [7334069283363865529](https://jules.google.com/task/7334069283363865529) started by @boxheed*